### PR TITLE
Added missing docstring for AggregatorLogEntry data structure

### DIFF
--- a/temp/analyser.go
+++ b/temp/analyser.go
@@ -17,6 +17,7 @@ type PipelineLogEntry struct {
 	Message  string `json:"message"`
 }
 
+// AggregatorLogEntry represents one log entry (record) read from log file.
 type AggregatorLogEntry struct {
 	Level        string `json:"level"`
 	Time         string `json:"time"`


### PR DESCRIPTION
# Description

Added missing docstring for `AggregatorLogEntry` data structure

Fixes #120

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

N/A